### PR TITLE
Fix "'normal' plaintext type" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This is encoded in a document as ['some ', (2 tombstones), 'string']
 (It should be encoded as {s:'some string', t:[5, -2, 6]} because thats
 faster in JS, but its not.)
 
-Just like in the 'normal' [plaintext type](/ottypes/text), Ops are lists of
+Just like in the 'normal' [plaintext type](https://github.com/ottypes/text), Ops are lists of
 components which iterate over the whole document.
 
 Components are either:


### PR DESCRIPTION
It's currently a relative link to nowhere:
![image](https://cloud.githubusercontent.com/assets/225809/13728009/d26e8646-e8bd-11e5-86d5-e36a59f950ab.png)
